### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/m426-Scrum/src/lib/definitions.ts
+++ b/m426-Scrum/src/lib/definitions.ts
@@ -225,7 +225,7 @@ export const SignUpFormSchema = z.object({
   password: z
     .string()
     .min(8, { message: 'Be at least 8 characters long' })
-    .regex(/[a-zA-z]/, { message: 'Contain at least one letter.' })
+    .regex(/[a-zA-Z]/, { message: 'Contain at least one letter.' })
     .regex(/[0-9]/, {message: 'Contain at least one number.' })
     .regex(/[^a-zA-Z0-9]/, {
       message: 'Contain at least one special character.',


### PR DESCRIPTION
Potential fix for [https://github.com/sxpersxnic/TBZ/security/code-scanning/1](https://github.com/sxpersxnic/TBZ/security/code-scanning/1)

To fix the issue, the overly permissive range `A-z` should be replaced with two explicit ranges: `A-Z` for uppercase letters and `a-z` for lowercase letters. This ensures that only alphabetic characters are matched, avoiding unintended matches with non-alphabetic characters. The corrected regular expression will be `/[a-zA-Z]/`.

The change will be made on line 228 in the `SignUpFormSchema` definition. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
